### PR TITLE
Fixed the removeEmptyReason out of bounds test case and contract

### DIFF
--- a/contracts/modules/token/TokenController.sol
+++ b/contracts/modules/token/TokenController.sol
@@ -654,6 +654,7 @@ contract TokenController is ITokenController, LockHandler, LegacyMasterAware {
   function _removeEmptyReason(address _of, bytes32 _reason, uint _index) internal {
 
     uint lastReasonIndex = lockReason[_of].length.sub(1, "TokenController: lockReason is empty");
+    require(lastReasonIndex >= _index, "TokenController: bad reason index");
 
     require(lockReason[_of][_index] == _reason, "TokenController: bad reason index");
     require(locked[_of][_reason].amount == 0, "TokenController: reason amount is not zero");

--- a/contracts/modules/token/TokenController.sol
+++ b/contracts/modules/token/TokenController.sol
@@ -654,7 +654,7 @@ contract TokenController is ITokenController, LockHandler, LegacyMasterAware {
   function _removeEmptyReason(address _of, bytes32 _reason, uint _index) internal {
 
     uint lastReasonIndex = lockReason[_of].length.sub(1, "TokenController: lockReason is empty");
-    require(lastReasonIndex >= _index, "TokenController: bad reason index");
+    require(lastReasonIndex > _index, "TokenController: bad reason index");
 
     require(lockReason[_of][_index] == _reason, "TokenController: bad reason index");
     require(locked[_of][_reason].amount == 0, "TokenController: reason amount is not zero");

--- a/test/unit/TokenController/removeEmptyReason.js
+++ b/test/unit/TokenController/removeEmptyReason.js
@@ -36,7 +36,10 @@ describe('removeEmptyReason', function () {
     await token.approve(tokenController.address, ether('100'), { from: member });
     await tokenController.lockOf(member, R0, ether('100'), lockPeriod, { from: internal });
 
-    await tokenController.removeEmptyReason(member, '0x', '1');
+    await expectRevert(
+      tokenController.removeEmptyReason(member, '0x', '1'),
+      'TokenController: bad reason index',
+    );
   });
 
   it('reverts when index points to a different reason', async function () {


### PR DESCRIPTION
Concerned with the issue pointed out in https://github.com/nomiclabs/hardhat/issues/1864, and after some review on popular sources such as [StackExchange](https://ethereum.stackexchange.com/questions/83222/vm-exception-while-processing-transaction-invalid-opcode-error/83246#comment103547_83246), there seems to be a problem in the _Ethereum VM_ when trying to access to an index which is out of bounds in a contract.

The studied test case tries to access an out of bounds index of a contract's internal array, which produces an error in the _Ethereum VM_, resulting in the bad behavior of the application, which throws an _invalid opcode_ exception, as shown in the logs of the referred issue.

For the purpose of fixing the issue, a length check has been added to the contract `_removeEmptyReason` function, while the problematic test case was redefined in a way that it expects a revert, as its name points out.

Accepting that this issue solves the problem had would close https://github.com/nomiclabs/hardhat/issues/1864 and, probably, would show a hint for where to look in the https://github.com/nomiclabs/hardhat/issues/1996.